### PR TITLE
sensors: set max range of proximity sensor to 1

### DIFF
--- a/hidl/sensors/Sensors.cpp
+++ b/hidl/sensors/Sensors.cpp
@@ -137,6 +137,7 @@ Return<void> Sensors::getSensorsList(getSensorsList_cb _hidl_cb) {
             LOG(INFO) << "Fixing com.samsung.sensor.physical_proximity";
             dst->type = SensorType::PROXIMITY;
             dst->typeAsString = SENSOR_STRING_TYPE_PROXIMITY;
+            dst->maxRange = 1;
         }
     }
 


### PR DESCRIPTION
Samsung's proximity sensor type is binary in nature.
There are only two state: FAR and NEAR.

However, Samsung uses values between min and max for
other purposes like proximity detection during Always-On
Display.

This breaks proximity detection during Doze for AOSP as
AOSP only considers the proximity sensor in FAR state
when the value equals or larger than max.

Thus, this change sets the max to 1 so any > 1 value
would be considered as FAR and the behavior of this vendor
proximity sensor type matches the behavior expected by AOSP.

Change-Id: I56af8e2ae743b47e3c4894e5ef68ce0b54e5cfdb