### PR TITLE
power-libperfmgr: move double tap to wake out of setInteractive()

### DIFF
--- a/hidl/power-libperfmgr/Power.cpp
+++ b/hidl/power-libperfmgr/Power.cpp
@@ -125,6 +125,10 @@ Power::Power()
         // Now start to take powerhint
         mReady.store(true);
         ALOGI("PowerHAL ready to process hints");
+
+        // setFeature() is called before loading powerhint.json
+        // is finished so update dt2w state here
+	switchDT2W(mDoubleTapEnabled);
     });
     mNumPerfProfiles = android::base::GetIntProperty(kPowerHalProfileNumProp, 0);
     mInitThread.detach();
@@ -186,24 +190,16 @@ Return<void> Power::setProfile(PowerProfile profile) {
     return Void();
 }
 
+Return<void> Power::switchDT2W(bool dt2w) {
+    updateHint("DOUBLE_TAP_TO_WAKE", dt2w);
+    std::this_thread::sleep_for(20ms);
+
+    return Void();
+}
+
 // Methods from ::android::hardware::power::V1_0::IPower follow.
 Return<void> Power::setInteractive(bool interactive) {
-    // Enable dt2w before turning TSP off
-    if (mDoubleTapEnabled && !interactive) {
-       updateHint("DOUBLE_TAP_TO_WAKE", true);
-       // It takes some time till the cmd is executed in the Kernel, there
-       // is an interface to check that. To avoid that just wait for 25ms
-       // till we turn off the touchscreen and lcd.
-       std::this_thread::sleep_for(20ms);
-    }
-
     updateHint("NOT_INTERACTIVE", !interactive);
-
-    // Disable dt2w after turning TSP back on
-    if (mDoubleTapEnabled && interactive) {
-       updateHint("DOUBLE_TAP_TO_WAKE", false);
-       std::this_thread::sleep_for(10ms);
-    }
 
     return Void();
 }
@@ -283,6 +279,11 @@ Return<void> Power::setFeature(Feature feature, bool activate) {
     switch (feature) {
         case Feature::POWER_FEATURE_DOUBLE_TAP_TO_WAKE:
             mDoubleTapEnabled = activate;
+
+            // this is only called when the device is booting up or
+            // the user changed the dt2w setting so the touchscreen
+            // should always be on when this is called
+            switchDT2W(activate);
             break;
         default:
             break;

--- a/hidl/power-libperfmgr/Power.h
+++ b/hidl/power-libperfmgr/Power.h
@@ -102,6 +102,7 @@ class Power : public IPower, public ILineagePower {
 
     Return<void> updateHint(const char *hint, bool enable);
     Return<void> setProfile(PowerProfile profile);
+    Return<void> switchDT2W(bool dt2w);
 };
 
 }  // namespace implementation


### PR DESCRIPTION
enabling/disabling DT2W inside setInteractive() doesn't work correctly
on some newer samsung devices so enable/disable it only when the setting
has changed and on boot

Change-Id: I3a5d8471e007e5f78c7df8da3cc629fb452e72d9