### PR TITLE
livedisplay: Set sysfs ownership/perms on init for qcom

### DIFF
--- a/hidl/livedisplay/vendor.lineage.livedisplay@2.0-service.samsung-qcom.rc
+++ b/hidl/livedisplay/vendor.lineage.livedisplay@2.0-service.samsung-qcom.rc
@@ -1,3 +1,22 @@
+on init
+    # LiveDisplay sysfs
+    chown system system /sys/devices/virtual/graphics/fb0/acl
+    chmod 0660 /sys/devices/virtual/graphics/fb0/acl
+    chown system system /sys/devices/virtual/graphics/fb0/aco
+    chmod 0660 /sys/devices/virtual/graphics/fb0/aco
+    chown system system /sys/devices/virtual/graphics/fb0/cabc
+    chmod 0660 /sys/devices/virtual/graphics/fb0/cabc
+    chown system system /sys/devices/virtual/graphics/fb0/hbm
+    chmod 0660 /sys/devices/virtual/graphics/fb0/hbm
+    chown system system /sys/devices/virtual/graphics/fb0/rgb
+    chmod 0660 /sys/devices/virtual/graphics/fb0/rgb
+    chown system system /sys/devices/virtual/graphics/fb0/sre
+    chmod 0660 /sys/devices/virtual/graphics/fb0/sre
+    chown system system /sys/devices/virtual/graphics/fb0/color_enhance
+    chmod 0660 /sys/devices/virtual/graphics/fb0/color_enhance
+    chown system system /sys/devices/virtual/graphics/fb0/reading_mode
+    chmod 0660 /sys/devices/virtual/graphics/fb0/reading_mode
+
 on post-fs-data
     mkdir /data/vendor/display 0770 system system
 


### PR DESCRIPTION
* Change I87ec20e3b0c9e9559963bebe7221f51e1dd4d7f3 made assumptions
  that aren't true

Change-Id: I898362c1888ab46afbfad3ecbf8a94a70d2f6fd7