### PR TITLE
hidl: Don't compile setNotificationLED if there is no blink node

### DIFF
--- a/hidl/light/Light.cpp
+++ b/hidl/light/Light.cpp
@@ -55,12 +55,14 @@ Light::Light() {
                     std::bind(&Light::handleBacklight, this, std::placeholders::_1));
 #ifdef BUTTON_BRIGHTNESS_NODE
     mLights.emplace(Type::BUTTONS, std::bind(&Light::handleButtons, this, std::placeholders::_1));
-#endif
+#endif /* BUTTON_BRIGHTNESS_NODE */
+#ifdef LED_BLINK_NODE
     mLights.emplace(Type::BATTERY, std::bind(&Light::handleBattery, this, std::placeholders::_1));
     mLights.emplace(Type::NOTIFICATIONS,
                     std::bind(&Light::handleNotifications, this, std::placeholders::_1));
     mLights.emplace(Type::ATTENTION,
                     std::bind(&Light::handleAttention, this, std::placeholders::_1));
+#endif /* LED_BLINK_NODE */
 }
 
 Return<Status> Light::setLight(Type type, const LightState& state) {
@@ -103,6 +105,7 @@ void Light::handleButtons(const LightState& state) {
 }
 #endif
 
+#ifdef LED_BLINK_NODE
 void Light::handleBattery(const LightState& state) {
     mBatteryState = state;
     setNotificationLED();
@@ -123,14 +126,14 @@ void Light::setNotificationLED() {
     LightState state;
 #ifdef LED_BLN_NODE
     bool bln = false;
-#endif
+#endif /* LED_BLN_NODE */
 
     if (mNotificationState.color & COLOR_MASK) {
         adjusted_brightness = LED_BRIGHTNESS_NOTIFICATION;
         state = mNotificationState;
 #ifdef LED_BLN_NODE
         bln = true;
-#endif
+#endif /* LED_BLN_NODE */
     } else if (mAttentionState.color & COLOR_MASK) {
         adjusted_brightness = LED_BRIGHTNESS_ATTENTION;
         state = mAttentionState;
@@ -164,8 +167,18 @@ void Light::setNotificationLED() {
     if (bln) {
         set(LED_BLN_NODE, (state.color & COLOR_MASK) ? 1 : 0);
     }
-#endif
+#endif /* LED_BLN_NODE */
 }
+
+uint32_t Light::calibrateColor(uint32_t color, int32_t brightness) {
+    uint32_t red = ((color >> 16) & 0xFF) * LED_ADJUSTMENT_R;
+    uint32_t green = ((color >> 8) & 0xFF) * LED_ADJUSTMENT_G;
+    uint32_t blue = (color & 0xFF) * LED_ADJUSTMENT_B;
+
+    return (((red * brightness) / 255) << 16) + (((green * brightness) / 255) << 8) +
+           ((blue * brightness) / 255);
+}
+#endif /* LED_BLINK_NODE */
 
 Return<void> Light::getSupportedTypes(getSupportedTypes_cb _hidl_cb) {
     std::vector<Type> types;
@@ -184,15 +197,6 @@ uint32_t Light::rgbToBrightness(const LightState& state) {
 
     return ((77 * ((color >> 16) & 0xff)) + (150 * ((color >> 8) & 0xff)) + (29 * (color & 0xff))) >>
            8;
-}
-
-uint32_t Light::calibrateColor(uint32_t color, int32_t brightness) {
-    uint32_t red = ((color >> 16) & 0xFF) * LED_ADJUSTMENT_R;
-    uint32_t green = ((color >> 8) & 0xFF) * LED_ADJUSTMENT_G;
-    uint32_t blue = (color & 0xFF) * LED_ADJUSTMENT_B;
-
-    return (((red * brightness) / 255) << 16) + (((green * brightness) / 255) << 8) +
-           ((blue * brightness) / 255);
 }
 
 }  // namespace implementation

--- a/hidl/light/Light.h
+++ b/hidl/light/Light.h
@@ -48,17 +48,20 @@ struct Light : public ILight {
     void handleBacklight(const LightState& state);
 #ifdef BUTTON_BRIGHTNESS_NODE
     void handleButtons(const LightState& state);
-#endif
+#endif /* BUTTON_BRIGHTNESS_NODE */
+#ifdef LED_BLINK_NODE
     void handleBattery(const LightState& state);
     void handleNotifications(const LightState& state);
     void handleAttention(const LightState& state);
     void setNotificationLED();
-    uint32_t rgbToBrightness(const LightState& state);
     uint32_t calibrateColor(uint32_t color, int32_t brightness);
 
     LightState mAttentionState;
     LightState mBatteryState;
     LightState mNotificationState;
+#endif /* LED_BLINK_NODE */
+
+    uint32_t rgbToBrightness(const LightState& state);
 
     std::mutex mLock;
     std::unordered_map<Type, std::function<void(const LightState&)>> mLights;


### PR DESCRIPTION
For example exynos9820 doesn't provide a LED.

Change-Id: I745f179fae52816c915833321123c8f49ba0a7d2
(cherry picked from commit eeb666cf009bb24951ff321aa64ff4938c716ac4)