### PR TITLE
libsecril-client: add support for P libsec-ril.so

### DIFF
--- a/ril/libsecril-client/Android.mk
+++ b/ril/libsecril-client/Android.mk
@@ -22,6 +22,10 @@ ifneq ($(filter m7450 mdm9x35 ss333 xmm7260,$(BOARD_MODEM_TYPE)),)
 LOCAL_CFLAGS += -DSAMSUNG_NEXT_GEN_MODEM
 endif
 
+ifeq ($(TARGET_USES_VND_SECRIL), true)
+LOCAL_CFLAGS += -DUSES_VND_SECRIL
+endif
+
 LOCAL_MODULE:= libsecril-client
 LOCAL_PRELINK_MODULE := false
 

--- a/ril/libsecril-client/secril-client.cpp
+++ b/ril/libsecril-client/secril-client.cpp
@@ -35,9 +35,14 @@ namespace android {
 // Defines
 //---------------------------------------------------------------------------
 #define RILD_PORT               7777
+#ifdef USES_VND_SECRIL
+#define MULTI_CLIENT_SOCKET_NAME "VND_Multiclient"
+#define MULTI_CLIENT_SOCKET_NAME_2 "VND_Multiclient2"
+#else
 #define MULTI_CLIENT_SOCKET_NAME "Multiclient"
-#define MULTI_CLIENT_Q_SOCKET_NAME "QMulticlient"
 #define MULTI_CLIENT_SOCKET_NAME_2 "Multiclient2"
+#endif
+#define MULTI_CLIENT_Q_SOCKET_NAME "QMulticlient"
 
 #define MAX_COMMAND_BYTES       (8 * 1024)
 #define REQ_POOL_SIZE           32


### PR DESCRIPTION
 * From P onward samsung changed the socket name in libsec-ril.so from
   Multiclient to VND_Multiclient.

 * In order to not break compatibility with older RIL stack guard this
   behind TARGET_USES_VND_SECRIL.

 * This is mostly relevant when using P (or newer) prebuilt ril stack
   coupled with OSS audio hal from hw/samsung, which depends on OSS
   libsecril-client to provide connection to the RIL daemon.

Change-Id: Iab5d07f2301d33216bbdf3e18f844522e32fadce